### PR TITLE
Update ReviewDebtor.tpl

### DIFF
--- a/extension/templates/CRM/Banking/Page/ReviewDebtor.tpl
+++ b/extension/templates/CRM/Banking/Page/ReviewDebtor.tpl
@@ -38,7 +38,7 @@
             {if $contact}
                 <div class="btxlabel">{ts domain='org.project60.banking'}Contact{/ts}</div>
                 <div class="btxvalue btxl">
-                    <a href="{$base_url}/civicrm/contact/view?reset=1&cid={$contact.id}">{$contact.display_name}&nbsp;[{$contact.id}]</a>
+                    <a href="{crmURL p="civicrm/contact/view" q="reset=1&cid=$contact_id"}">{$contact.display_name}&nbsp;[{$contact.id}]</a>
                 </div>
             {/if}
         </td>


### PR DESCRIPTION
Link to contact redirects to contact view in frontend, not in CRM (at least on WordPress). Therefore changed from baseURL to crmURL.